### PR TITLE
87 normalization module

### DIFF
--- a/configs/datamodule/transforms/preprocessing/default.yaml
+++ b/configs/datamodule/transforms/preprocessing/default.yaml
@@ -1,4 +1,6 @@
 normalize: True
+mean: -4.268 # Mean of log-scaled Mel spectrograms from AuioSet
+std: 4.569 # Standard deviation of log-scaled Mel spectrograms from AuioSet
 use_spectrogram: True
 n_fft: 1024
 hop_length: 79

--- a/src/datamodule/components/calculate_normalization_parameters.py
+++ b/src/datamodule/components/calculate_normalization_parameters.py
@@ -9,9 +9,10 @@ from src.datamodule.components.normalization import NormalizationWrapper
 log = utils.get_pylogger(__name__)
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
+
 @hydra.main(version_base=None, config_path="../../../configs", config_name="main")
 def calculate_normalization_parameters(cfg):
-    log.info('Using config: \n%s', OmegaConf.to_yaml(cfg))
+    log.info("Using config: \n%s", OmegaConf.to_yaml(cfg))
 
     log.info(f"Dataset path: <{os.path.abspath(cfg.paths.dataset_path)}>")
     os.makedirs(cfg.paths.dataset_path, exist_ok=True)
@@ -27,23 +28,14 @@ def calculate_normalization_parameters(cfg):
     log.info(f"Instantiate datamodule <{cfg.datamodule._target_}>")
     datamodule = hydra.utils.instantiate(cfg.datamodule, _recursive_=False)
 
-    log.info(f"normalize: {datamodule.transforms_config.preprocessing.normalize}")
-    log.info(f"wave augmentations: {datamodule.transforms_config.waveform_augmentations}")
-    log.info(f"spec augmentations: {datamodule.transforms_config.spectrogram_augmentations}")
-
-
-    # Set the normalization in the config file to False, since we do not want normalized data for the mean and standard deviation calculations.
+    # Set the normalization in the config file to False, since we do not want normalized data for the mean and
+    # standard deviation calculations.
     datamodule.transforms_config.preprocessing.normalize = False
 
-    log.info(f"normalize: {datamodule.transforms_config.preprocessing.normalize}")
-
-    # Set the augmentations in the config file to None, since we do not want augmentations for the mean and standard deviation calculations.
+    # Set the augmentations in the config file to None, since we do not want augmentations for the mean and
+    # standard deviation calculations.
     datamodule.transforms_config.waveform_augmentations = None
     datamodule.transforms_config.spectrogram_augmentations = None
-
-    log.info(f"wave augmentations: {datamodule.transforms_config.waveform_augmentations}")
-    log.info(f"spec augmentations: {datamodule.transforms_config.spectrogram_augmentations}")
-
 
     datamodule.prepare_data()
 
@@ -51,9 +43,12 @@ def calculate_normalization_parameters(cfg):
 
     normalizer = NormalizationWrapper(config=datamodule.transforms_config)
 
-    mean, std = normalizer.calculate_mean_std_from_dataloader(dataloader=datamodule.train_dataloader())
+    mean, std = normalizer.calculate_mean_std_from_dataloader(
+        dataloader=datamodule.train_dataloader()
+    )
 
     log.info(f"Mean: {mean} | Standard deviation: {std}")
+
 
 if __name__ == "__main__":
     calculate_normalization_parameters()

--- a/src/datamodule/components/calculate_normalization_parameters.py
+++ b/src/datamodule/components/calculate_normalization_parameters.py
@@ -9,7 +9,7 @@ from src.datamodule.components.normalization import NormalizationWrapper
 log = utils.get_pylogger(__name__)
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
-@hydra.main(version_base=None, config_path="../configs", config_name="main")
+@hydra.main(version_base=None, config_path="../../../configs", config_name="main")
 def calculate_normalization_parameters(cfg):
     log.info('Using config: \n%s', OmegaConf.to_yaml(cfg))
 

--- a/src/datamodule/components/calculate_normalization_parameters.py
+++ b/src/datamodule/components/calculate_normalization_parameters.py
@@ -1,0 +1,59 @@
+import os
+import rootutils
+import hydra
+import lightning as L
+from omegaconf import OmegaConf
+from src import utils
+from src.datamodule.components.normalization import NormalizationWrapper
+
+log = utils.get_pylogger(__name__)
+rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+
+@hydra.main(version_base=None, config_path="../configs", config_name="main")
+def calculate_normalization_parameters(cfg):
+    log.info('Using config: \n%s', OmegaConf.to_yaml(cfg))
+
+    log.info(f"Dataset path: <{os.path.abspath(cfg.paths.dataset_path)}>")
+    os.makedirs(cfg.paths.dataset_path, exist_ok=True)
+
+    log.info(f"Log path: <{os.path.abspath(cfg.paths.log_dir)}>")
+    os.makedirs(cfg.paths.log_dir, exist_ok=True)
+
+    log.info(f"Seed everything with <{cfg.seed}>")
+    L.seed_everything(cfg.seed)
+    log.info(f"Instantiate logger {[loggers for loggers in cfg['logger']]}")
+
+    # Setup data
+    log.info(f"Instantiate datamodule <{cfg.datamodule._target_}>")
+    datamodule = hydra.utils.instantiate(cfg.datamodule, _recursive_=False)
+
+    log.info(f"normalize: {datamodule.transforms_config.preprocessing.normalize}")
+    log.info(f"wave augmentations: {datamodule.transforms_config.waveform_augmentations}")
+    log.info(f"spec augmentations: {datamodule.transforms_config.spectrogram_augmentations}")
+
+
+    # Set the normalization in the config file to False, since we do not want normalized data for the mean and standard deviation calculations.
+    datamodule.transforms_config.preprocessing.normalize = False
+
+    log.info(f"normalize: {datamodule.transforms_config.preprocessing.normalize}")
+
+    # Set the augmentations in the config file to None, since we do not want augmentations for the mean and standard deviation calculations.
+    datamodule.transforms_config.waveform_augmentations = None
+    datamodule.transforms_config.spectrogram_augmentations = None
+
+    log.info(f"wave augmentations: {datamodule.transforms_config.waveform_augmentations}")
+    log.info(f"spec augmentations: {datamodule.transforms_config.spectrogram_augmentations}")
+
+
+    datamodule.prepare_data()
+
+    datamodule.setup(stage="fit")
+
+    normalizer = NormalizationWrapper(config=datamodule.transforms_config)
+
+    mean, std = normalizer.calculate_mean_std_from_dataloader(dataloader=datamodule.train_dataloader)
+
+    log.info(f"Mean: {mean} | Standard deviation: {std}")
+
+if __name__ == "__main__":
+    calculate_normalization_parameters()

--- a/src/datamodule/components/calculate_normalization_parameters.py
+++ b/src/datamodule/components/calculate_normalization_parameters.py
@@ -51,7 +51,7 @@ def calculate_normalization_parameters(cfg):
 
     normalizer = NormalizationWrapper(config=datamodule.transforms_config)
 
-    mean, std = normalizer.calculate_mean_std_from_dataloader(dataloader=datamodule.train_dataloader)
+    mean, std = normalizer.calculate_mean_std_from_dataloader(dataloader=datamodule.train_dataloader())
 
     log.info(f"Mean: {mean} | Standard deviation: {std}")
 

--- a/src/datamodule/components/normalization.py
+++ b/src/datamodule/components/normalization.py
@@ -28,15 +28,16 @@ class NormalizationWrapper:
             std (float): Standard deviation for standardization.
         """
 
-        self.config = config
+        self.config = config.get("preprocessing")
         self.dataset = dataset
         self.dataloader = None  # Set as None initially; can be assigned later
 
         # Extract the use_spectrogram flag from config; ensure it's a boolean
         self.use_spectrogram = config.get("use_spectrogram", False)
 
-        # Retrieve or calculate mean and standard deviation
-        self.mean, self.std = self.get_mean_std()
+        if self.config.normalize:
+            # Retrieve or calculate mean and standard deviation
+            self.mean, self.std = self.get_mean_std()
 
     def standardize_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
         """

--- a/src/datamodule/components/normalization.py
+++ b/src/datamodule/components/normalization.py
@@ -22,7 +22,6 @@ class NormalizationWrapper:
         Attributes:
             config (DictConfig): Configuration dictionary.
             dataset (Optional[datasets.Dataset]): Dataset for normalization.
-            dataloader (DataLoader): DataLoader, initialized as None and can be set later for mean and std calculation.
             use_spectrogram (bool): Flag to determine if spectrogram or waveform data should be used.
             mean (float): Mean value for standardization.
             std (float): Standard deviation for standardization.
@@ -30,7 +29,6 @@ class NormalizationWrapper:
 
         self.config = config.get("preprocessing")
         self.dataset = dataset
-        self.dataloader = None  # Set as None initially; can be assigned later
 
         # Extract the use_spectrogram flag from config; ensure it's a boolean
         self.use_spectrogram = config.get("use_spectrogram", False)
@@ -164,4 +162,5 @@ class NormalizationWrapper:
 
         mean = sum_ / num_elements
         std = (sum_of_squares / num_elements - mean**2) ** 0.5
+
         return mean, std

--- a/src/datamodule/components/normalization.py
+++ b/src/datamodule/components/normalization.py
@@ -1,0 +1,151 @@
+from typing import Optional, Tuple
+
+import datasets
+import torch
+from omegaconf import DictConfig
+from torch.utils.data import DataLoader
+
+
+# TODO: Also add logs to this function
+class NormalizationWrapper:
+    def __init__(
+        self, config: DictConfig, dataset: Optional[datasets.Dataset] = None
+    ) -> None:
+        """
+        Initializes the NormalizationWrapper module.
+
+        Args:
+            config (DictConfig): Configuration for normalization, including mean, std, and whether to use spectrogram.
+            dataset (Optional[datasets.Dataset]): The dataset to be used for calculating mean and std, if not provided
+            in config. Defaults to None.
+
+        Attributes:
+            config (DictConfig): Configuration dictionary.
+            dataset (Optional[datasets.Dataset]): Dataset for normalization.
+            dataloader (DataLoader): DataLoader, initialized as None and can be set later for mean and std calculation.
+            use_spectrogram (bool): Flag to determine if spectrogram or waveform data should be used.
+            mean (float): Mean value for standardization.
+            std (float): Standard deviation for standardization.
+        """
+
+        self.config = config
+        self.dataset = dataset
+        self.dataloader = None  # Set as None initially; can be assigned later
+
+        # Extract the use_spectrogram flag from config; ensure it's a boolean
+        self.use_spectrogram = config.get("use_spectrogram", False)
+
+        # Retrieve or calculate mean and standard deviation
+        self.mean, self.std = self.get_mean_std()
+
+    def standardize_tensor(self, tensor: torch.Tensor) -> torch.Tensor:
+        """
+        Standardizes a given tensor using the pre-calculated mean and standard deviation.
+
+        Args:
+            tensor (torch.Tensor): The input tensor to be standardized.
+
+        Returns:
+            torch.Tensor: The standardized tensor.
+
+        Note:
+            The standardization formula used is: (tensor - mean) / std.
+        """
+
+        # Standardize the tensor using the pre-calculated mean and standard deviation
+        return (tensor - self.mean) / self.std
+
+    def get_mean_std(self) -> Tuple[float, float]:
+        """
+        Retrieves or calculates the mean and standard deviation for normalization.
+
+        Tries to fetch the mean and std from the config, then from the dataset, and
+        if still not found, calculates them using the dataloader.
+
+        Returns:
+            Tuple[float, float]: A tuple containing the mean and standard deviation.
+        """
+
+        # Try to get mean and std from config
+        mean, std = self.get_mean_std_from_config(self.config)
+
+        # If not found in config, try to get them from the dataset
+        if mean is None or std is None:
+            mean, std = self.get_mean_std_from_dataset(self.dataset)
+
+        # If still not found, calculate from the dataloader
+        if mean is None or std is None and self.dataloader:
+            mean, std = self.calculate_mean_std_from_dataloader(self.dataloader)
+
+        return mean, std
+
+    def get_mean_std_from_config(
+        self, config: DictConfig
+    ) -> Tuple[Optional[float], Optional[float]]:
+        """
+        Attempts to retrieve the mean and standard deviation from the provided configuration object.
+
+        Args:
+            config (DictConfig): Configuration object containing potential mean and standard deviation values.
+
+        Returns:
+            Tuple[Optional[float], Optional[float]]: A tuple containing the mean and standard deviation.
+            Returns (None, None) if they are not specified in the config.
+        """
+
+        mean = config.get("normalization", {}).get("mean")
+        std = config.get("normalization", {}).get("std")
+
+        return mean, std
+
+    def get_mean_std_from_dataset(
+        self, dataset: datasets.Dataset
+    ) -> Tuple[Optional[float], Optional[float]]:
+        """
+        Attempts to retrieve the mean and standard deviation from the provided dataset.
+
+        Args:
+            dataset (datasets.Dataset): The dataset which might contain mean and standard deviation values.
+
+        Returns:
+            Tuple[Optional[float], Optional[float]]: A tuple containing the mean and standard deviation.
+            Returns (None, None) if they are not specified in the dataset.
+        """
+
+        # Depending on the flag 'use_spectrogram', fetch the appropriate mean and std keys
+        mean_key, std_key = (
+            ("spectrogram_mean", "spectrogram_std")
+            if self.use_spectrogram
+            else ("waveform_mean", "waveform_std")
+        )
+
+        mean = dataset.get(mean_key)
+        std = dataset.get(std_key)
+
+        return mean, std
+
+    # TODO: Check if its smarter to caclucate the mean and std from a PyTorch dataloader or Hugging Face dataset
+    def calculate_mean_std_from_dataloader(
+        self, dataloader: DataLoader
+    ) -> Tuple[float, float]:
+        """
+        Calculates the mean and standard deviation from a PyTorch DataLoader.
+
+        Args:
+            dataloader (DataLoader): The DataLoader containing the dataset for calculation.
+
+        Returns:
+            Tuple[float, float]: The calculated mean and standard deviation.
+        """
+
+        sum_, sum_of_squares, num_elements = 0.0, 0.0, 0
+
+        for batch in dataloader:
+            input_values = batch["input_values"]
+            sum_ += input_values.sum()
+            sum_of_squares += (input_values**2).sum()
+            num_elements += input_values.nelement()
+
+        mean = sum_ / num_elements
+        std = (sum_of_squares / num_elements - mean**2) ** 0.5
+        return mean, std

--- a/src/datamodule/components/transforms.py
+++ b/src/datamodule/components/transforms.py
@@ -59,7 +59,7 @@ class TransformsWrapperN:
                 self.wave_aug = None
 
             # spectrogram augmentations
-            if self.waveform_augmentations:
+            if self.spectrogram_augmentations:
                 spec_aug = []
                 for spec_aug_name in self.spectrogram_augmentations:
                     aug = hydra.utils.instantiate(
@@ -80,7 +80,7 @@ class TransformsWrapperN:
         self.mode = mode
 
     def _spectrogram_conversion(self, waveform):
-        if "time_stretch" in self.spectrogram_augmentations:
+        if self.spectrogram_augmentations and "time_stretch" in self.spectrogram_augmentations:
             spectrogram_transform = torchaudio.transforms.Spectrogram(
                 n_fft=self.preprocessing.n_fft,
                 hop_length=self.preprocessing.hop_length,

--- a/src/datamodule/components/transforms.py
+++ b/src/datamodule/components/transforms.py
@@ -43,27 +43,34 @@ class TransformsWrapperN:
 
         if self.mode == "train":
             # waveform augmentations
-            wave_aug = []
-            for wave_aug_name in self.waveform_augmentations:
-                aug = hydra.utils.instantiate(
-                    self.waveform_augmentations.get(wave_aug_name), _convert_="object"
-                )
-                wave_aug.append(aug)
+            if self.waveform_augmentations:
+                wave_aug = []
+                for wave_aug_name in self.waveform_augmentations:
+                    aug = hydra.utils.instantiate(
+                        self.waveform_augmentations.get(wave_aug_name),
+                        _convert_="object",
+                    )
+                    wave_aug.append(aug)
 
-            self.wave_aug = torch_audiomentations.Compose(
-                transforms=wave_aug, output_type="tensor"
-            )
+                self.wave_aug = torch_audiomentations.Compose(
+                    transforms=wave_aug, output_type="tensor"
+                )
+            else:
+                self.wave_aug = None
 
             # spectrogram augmentations
-            spec_aug = []
-            for spec_aug_name in self.spectrogram_augmentations:
-                aug = hydra.utils.instantiate(
-                    self.spectrogram_augmentations.get(spec_aug_name),
-                    _convert_="object",
-                )
-                spec_aug.append(aug)
+            if self.waveform_augmentations:
+                spec_aug = []
+                for spec_aug_name in self.spectrogram_augmentations:
+                    aug = hydra.utils.instantiate(
+                        self.spectrogram_augmentations.get(spec_aug_name),
+                        _convert_="object",
+                    )
+                    spec_aug.append(aug)
 
-            self.spec_aug = torchvision.transforms.Compose(transforms=spec_aug)
+                self.spec_aug = torchvision.transforms.Compose(transforms=spec_aug)
+            else:
+                self.spec_aug = None
 
         elif self.mode in ("valid", "test", "predict"):
             self.wave_aug = None

--- a/src/datamodule/components/transforms.py
+++ b/src/datamodule/components/transforms.py
@@ -43,8 +43,9 @@ class TransformsWrapperN:
 
         if self.mode == "train":
             # waveform augmentations
+
+            wave_aug = []
             if self.waveform_augmentations:
-                wave_aug = []
                 for wave_aug_name in self.waveform_augmentations:
                     aug = hydra.utils.instantiate(
                         self.waveform_augmentations.get(wave_aug_name),
@@ -55,12 +56,11 @@ class TransformsWrapperN:
                 self.wave_aug = torch_audiomentations.Compose(
                     transforms=wave_aug, output_type="tensor"
                 )
-            else:
-                self.wave_aug = None
 
             # spectrogram augmentations
+
+            spec_aug = []
             if self.waveform_augmentations:
-                spec_aug = []
                 for spec_aug_name in self.spectrogram_augmentations:
                     aug = hydra.utils.instantiate(
                         self.spectrogram_augmentations.get(spec_aug_name),
@@ -69,8 +69,6 @@ class TransformsWrapperN:
                     spec_aug.append(aug)
 
                 self.spec_aug = torchvision.transforms.Compose(transforms=spec_aug)
-            else:
-                self.spec_aug = None
 
         elif self.mode in ("valid", "test", "predict"):
             self.wave_aug = None


### PR DESCRIPTION
- Created a normalization.py file in src/datamodule/components that contains a NormalizationWrapper to handle normalization.
- The NormalizationWrapper checks if a mean and a standard deviation are available in the config file or in the HF dataset, and uses them to z standardize the inputs.
- Added the NormalizationWrapper to base_datamodule.py - it is called in the prepare_data function since it needs access to the HF dataset.
- Also moved the initialization of the TransformsWrapper from the init to the prepare_data function of the base datamodule, since it requires the NormalizationWrapper.
- Updated the normalization operation in the TransformsWrapper (transforms.py) - now the NormalizationWrapper is used to normalize the input.
- Added a calculate_normalization_parameters.py in src/datamodule/components that can be used to calculate the mean and standard deviation for a data set.