### PR TITLE
TransformsWrapper Base Class

### DIFF
--- a/configs/datamodule/transforms/base_transform.yaml
+++ b/configs/datamodule/transforms/base_transform.yaml
@@ -1,4 +1,4 @@
-_target_: src.datamodule.components.transforms.BaseTransformer
+_target_: src.datamodule.components.transforms.BaseTransforms
 sampling_rate: ${module.network.sampling_rate}
 task: ${datamodule.dataset.task}
 max_length: ${module.network.model.tf_model.window_size_s} # Attention: this might not work with any model!! -> You must specify it or set to 5s as its done in code

--- a/src/datamodule/base_datamodule.py
+++ b/src/datamodule/base_datamodule.py
@@ -10,7 +10,7 @@ import lightning as L
 from datasets import load_dataset, load_from_disk, Audio, DatasetDict, Dataset, IterableDataset, IterableDatasetDict
 from torch.utils.data import DataLoader
 from src.datamodule.components.event_mapping import XCEventMapping
-from src.datamodule.components.transforms import TransformsWrapper
+from src.datamodule.components.transforms import BaseTransforms
 
 @dataclass
 class DatasetConfig:
@@ -52,7 +52,7 @@ class BaseDataModuleHF(L.LightningDataModule):
     Attributes:
         dataset (DatasetConfig): Configuration for the dataset. Defaults to an instance of `DatasetConfig`.
         loaders (LoadersConfig): Configuration for the data loaders. Defaults to an instance of `LoadersConfig`.
-        transforms (TransformsWrapper): Configuration for the data transformations. Defaults to an instance of `TransformsWrapper`.
+        transforms (BaseTransforms): Configuration for the data transformations. Defaults to an instance of `BaseTransforms`.
         extractors (DefaultFeatureExtractor): Configuration for the feature extraction. Defaults to an instance of `DefaultFeatureExtractor`.
 
     Methods:
@@ -69,7 +69,7 @@ class BaseDataModuleHF(L.LightningDataModule):
         mapper: XCEventMapping | None = None,
         dataset: DatasetConfig = DatasetConfig(),
         loaders: LoadersConfig = LoadersConfig(),
-        transforms: TransformsWrapper = TransformsWrapper(),
+        transforms: BaseTransforms = BaseTransforms(),
         ):
         super().__init__()
         self.dataset_config = dataset

--- a/src/datamodule/components/transforms.py
+++ b/src/datamodule/components/transforms.py
@@ -28,7 +28,7 @@ class PreprocessingConfig:
     normalize_spectorgram: bool = True
     normalize_waveform: Literal['instance_normalization', 'instance_min_max'] | None  = None
 
-class BaseTransformer:
+class BaseTransforms:
     """
     Base class to handle audio transformations for different model types and modes.
 
@@ -41,7 +41,7 @@ class BaseTransformer:
     """
     
     def __init__(self, 
-                 task: str = "multiclass", 
+                 task: Literal['multiclass', 'multilabel'] = "multiclass", 
                  sampling_rate:int = 3200, 
                  max_length:int = 5, 
                  decoding: EventDecoding | None = None,
@@ -137,7 +137,7 @@ class BaseTransformer:
 
         return batch
 
-class TransformsWrapper(BaseTransformer):
+class TransformsWrapper(BaseTransforms):
     """
     A class to handle audio transformations for different model types and modes.
 

--- a/src/datamodule/gadme_datamodule.py
+++ b/src/datamodule/gadme_datamodule.py
@@ -1,7 +1,7 @@
 from typing import Literal
 from collections import Counter
 from src.datamodule.components.event_decoding import EventDecoding
-from src.datamodule.components.transforms import TransformsWrapper
+from src.datamodule.components.transforms import BaseTransforms
 from src.datamodule.components.event_mapping import XCEventMapping
 from .base_datamodule import BaseDataModuleHF, DatasetConfig, LoadersConfig
 from datasets import DatasetDict
@@ -14,7 +14,7 @@ class GADMEDataModule(BaseDataModuleHF):
             self,
             dataset: DatasetConfig = DatasetConfig(),
             loaders: LoadersConfig = LoadersConfig(),
-            transforms: TransformsWrapper = TransformsWrapper(),
+            transforms: BaseTransforms = BaseTransforms(),
             mapper: XCEventMapping = XCEventMapping()
     ):
         super().__init__(


### PR DESCRIPTION
# This introduces a base-class for TransformsWrapper.

Previously, TransformsWrapper did waveform_augmentations by default, this however is not needed in some special cases. Therefore, a base-class is introduced.

BaseTransformer only applies:
- event_decoder
- feature_extractor

(those are assigned by default)

The config is supplied as well.