### PR TITLE
Bugfix for cmAP metric in multilabel.py s.t. it works for multi-GPU t…

### DIFF
--- a/src/modules/metrics/multilabel.py
+++ b/src/modules/metrics/multilabel.py
@@ -33,6 +33,12 @@ class cmAP(Metric):
         self.accumulated_labels.append(labels)
 
     def compute(self) -> torch.Tensor:
+        # Ensure that accumulated variables are lists
+        if not isinstance(self.accumulated_predictions, list):
+            self.accumulated_predictions = [self.accumulated_predictions]
+        if not isinstance(self.accumulated_labels, list):
+            self.accumulated_labels = [self.accumulated_labels]
+
         # Concatenate accumulated predictions and labels along the batch dimension
         all_predictions = torch.cat(self.accumulated_predictions, dim=0)
         all_labels = torch.cat(self.accumulated_labels, dim=0)


### PR DESCRIPTION
The cmAP metric showed some very strange behavior during multi-GPU training. In particular, self.accumulated_predictions and self.accumulated_labels were not always passed to the torch.cat function as lists, but sometimes directly as tensors, which the torch.cat function could not handle. So I changed the code to make sure that self.accumulated_predictions and self.accumulated_labels are always lists before being passed to torch.cat.