### PR TITLE
Enable disabling lr_scheduler in configs

### DIFF
--- a/src/modules/base_module.py
+++ b/src/modules/base_module.py
@@ -77,7 +77,7 @@ class BaseModule(L.LightningModule):
             _convert_='partial'
         )
 
-        if self.lrs_params.get("scheduler"):
+        if self.lrs_params is not None and self.lrs_params.get("scheduler"):
             num_training_steps = math.ceil((self.num_epochs * self.len_trainset) / self.batch_size*self.num_gpus) 
             # TODO: Handle the case when drop_last=True more explicitly   
 


### PR DESCRIPTION
When no lr_scheduler is wanted, the base_module will throw an exception as the parameters are not specified well. 
When adding the check for is not None, one can set the config:
module:
    lr_scheduler: null

in order to disable lr_scheduler.