### PR TITLE
use the fingerprints of all datasets to compute the save_path

### DIFF
--- a/birdset/datamodule/base_datamodule.py
+++ b/birdset/datamodule/base_datamodule.py
@@ -150,12 +150,14 @@ class BaseDataModuleHF(L.LightningDataModule):
         """
         dataset.set_format("np")
 
-        fingerprint = (
-            dataset[next(iter(dataset))]._fingerprint
-            if isinstance(dataset, DatasetDict)
-            else dataset._fingerprint
-        )  # changed to next_iter to be more robust
-
+        if isinstance(dataset, DatasetDict):
+            fingerprints = [dataset[split]._fingerprint for split in dataset]
+            fingerprint = "_".join(fingerprints)
+        elif isinstance(dataset, Dataset):
+            fingerprint = dataset._fingerprint
+        else:
+            raise ValueError("dataset must be a Dataset or DatasetDict")
+            
         self.disk_save_path = os.path.join(
             self.dataset_config.data_dir,
             f"{self.dataset_config.hf_name}_processed_{self.dataset_config.seed}_{fingerprint}",


### PR DESCRIPTION
Use the fingerprints of all datasets to compute the `save_path`. This also tracks changes in valid or test split.