### PR TITLE
avoid lambdas

### DIFF
--- a/birdset/datamodule/components/augmentations.py
+++ b/birdset/datamodule/components/augmentations.py
@@ -56,6 +56,14 @@ def pad_spectrogram_width(
     return padded_spectrogram
 
 
+def _choose_original_labels(target, background_target, snr):
+    return target
+
+
+def _make_union_labels(target, background_target, snr):
+    return torch.maximum(target, background_target)
+
+
 class RandomTimeStretch:
     def __init__(
         self,
@@ -307,12 +315,10 @@ class MultilabelMix(BaseWaveformTransform):
 
         self.mix_target = mix_target
         if mix_target == "original":
-            self._mix_target = lambda target, background_target, snr: target
+            self._mix_target = _choose_original_labels
 
         elif mix_target == "union":
-            self._mix_target = lambda target, background_target, snr: torch.maximum(
-                target, background_target
-            )
+            self._mix_target = _make_union_labels
         else:
             raise ValueError("mix_target must be one of 'original' or 'union'.")
 

--- a/birdset/utils/utils.py
+++ b/birdset/utils/utils.py
@@ -84,6 +84,12 @@ def get_args_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _rename_resolver(item, loss, metric):
+    return item.replace("__loss__", loss.__class__.__name__).replace(
+        "__metric__", metric.__class__.__name__
+    )
+
+
 # flexible metric and loss names for callbacks
 def register_custom_resolvers(
     version_base: str, config_path: str, config_name: str
@@ -134,9 +140,7 @@ def register_custom_resolvers(
 
         OmegaConf.register_new_resolver(
             "replace",
-            lambda item: item.replace("__loss__", loss.__class__.__name__).replace(
-                "__metric__", metric.__class__.__name__
-            ),
+            _rename_resolver,
         )
 
     def decorator(function: Callable) -> Callable:


### PR DESCRIPTION
I just replaced `lambda x:` syntax in 3 places with small helper functions, since lambda is not picklable (this leads to issues with saving model as pickle, and with multiprocessing)