### PR TITLE
Fixed augmentations error when using higher sampling rates

### DIFF
--- a/birdset/datamodule/components/augmentations.py
+++ b/birdset/datamodule/components/augmentations.py
@@ -876,7 +876,7 @@ class AddBackgroundNoise(BaseWaveformTransform):
 
             background_samples = audio(background_path)
             pieces.append(background_samples)
-            missing_num_samples -= background_samples.shape[-1]
+            missing_num_samples -= background_num_samples
 
         # the inner call to rms_normalize ensures concatenated pieces share the same RMS (1)
         # the outer call to rms_normalize ensures that the resulting background has an RMS of 1

--- a/birdset/datamodule/components/augmentations.py
+++ b/birdset/datamodule/components/augmentations.py
@@ -861,22 +861,22 @@ class AddBackgroundNoise(BaseWaveformTransform):
             background_path = random.choice(self.background_paths)
             background_num_samples = audio.get_num_samples(background_path)
 
-            if background_num_samples > missing_num_samples:
+            # If the background sample is longer than what we need, extract the exact amount
+            if background_num_samples >= missing_num_samples:
                 sample_offset = random.randint(
                     0, background_num_samples - missing_num_samples
                 )
-                num_samples = missing_num_samples
                 background_samples = audio(
                     background_path,
                     sample_offset=sample_offset,
-                    num_samples=num_samples,
+                    num_samples=missing_num_samples,
                 )
-                missing_num_samples = 0
-            else:
-                background_samples = audio(background_path)
-                missing_num_samples -= background_num_samples
+                pieces.append(background_samples)
+                break
 
+            background_samples = audio(background_path)
             pieces.append(background_samples)
+            missing_num_samples -= background_samples.shape[-1]
 
         # the inner call to rms_normalize ensures concatenated pieces share the same RMS (1)
         # the outer call to rms_normalize ensures that the resulting background has an RMS of 1

--- a/birdset/datamodule/components/augmentations.py
+++ b/birdset/datamodule/components/augmentations.py
@@ -872,6 +872,7 @@ class AddBackgroundNoise(BaseWaveformTransform):
                     num_samples=missing_num_samples,
                 )
                 pieces.append(background_samples)
+                # background_samples matches missing_num_samples, break out of while loop
                 break
 
             background_samples = audio(background_path)


### PR DESCRIPTION
We had an error in the Biofoundations project when running models with a sampling rate larger than 32000 due to a shape mismatch in the AddBackgroundNoise augmentation. This small change should fix this error as the shape stays the same!